### PR TITLE
Fix build errors caused by CompilerTypeSystemContext constructor

### DIFF
--- a/src/ILCompiler.Compiler/tests/DependencyGraphTests.cs
+++ b/src/ILCompiler.Compiler/tests/DependencyGraphTests.cs
@@ -34,7 +34,7 @@ namespace ILCompiler.Compiler.Tests
         public static IEnumerable<object[]> GetTestMethods()
         {
             var target = new TargetDetails(TargetArchitecture.X64, TargetOS.Windows, TargetAbi.CoreRT);
-            var context = new CompilerTypeSystemContext(target, SharedGenericsMode.CanonicalReferenceTypes, false);
+            var context = new CompilerTypeSystemContext(target, SharedGenericsMode.CanonicalReferenceTypes);
 
             context.InputFilePaths = new Dictionary<string, string> {
                 { "Test.CoreLib", @"Test.CoreLib.dll" },

--- a/src/ILCompiler.Compiler/tests/DevirtualizationTests.cs
+++ b/src/ILCompiler.Compiler/tests/DevirtualizationTests.cs
@@ -18,7 +18,7 @@ namespace ILCompiler.Compiler.Tests
         public DevirtualizationTests()
         {
             var target = new TargetDetails(TargetArchitecture.X64, TargetOS.Windows, TargetAbi.CoreRT);
-            _context = new CompilerTypeSystemContext(target, SharedGenericsMode.CanonicalReferenceTypes, false);
+            _context = new CompilerTypeSystemContext(target, SharedGenericsMode.CanonicalReferenceTypes);
 
             _context.InputFilePaths = new Dictionary<string, string> {
                 { "Test.CoreLib", @"Test.CoreLib.dll" },


### PR DESCRIPTION
The commit https://github.com/trylek/corert/commit/9accf9f6f05ae339b2d9249bdfacae1fde9a3e05 removed an argument from the CompilerTypeSystemContext constructor and caused errors when building corert